### PR TITLE
Update dependencies, remove tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,14 @@ documentation = "https://docs.rs/kosmos"
 
 [features]
 default = ["nasa"]
-
 nasa = []
 
-
 [dependencies]
-async-trait = "0.1.41"
-chrono = { version = "0.4.16", features = ["serde"] }
-reqwest = { version = "0.10.8", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_path_to_error = "0.1.3"
+async-trait = "0.1.42"
+chrono = { version = "^0.4.16", features = ["serde"] }
+reqwest = { version = "^0.11.0", features = ["json"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "*"
+serde_path_to_error = "^0.1.3"
 snafu = "0.6.9"
-tokio = { version = "0.2", features = ["full"] }
-url = { version = "2.1.1", features = ["serde"] }
+url = { version = "^2.2.0", features = ["serde"] }


### PR DESCRIPTION
Tokio was completely unneeded, and has been removed-most other dependencies have been updated, and made more compatiable with other versions